### PR TITLE
Added secant_wrapper to calculus.py for root finding task

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Remember you are in charge to have a review assigned if one available, also you 
 Once the review is finished the original author has 12 hours to fix the issues mentionend in the review.
 
 ## Task group 1 algorithm (2 members per algorithm)
-Use the four integral algorithms (simpson, adaptive trapezoid, trapezoid) to create a Jupyter notebook that imports the functions from `calculus.py` and use them to calculate and plot the integral of:
+Use the four integral algorithms (simpson, adaptive trapezoid, trapezoid) to calculate and plot the integral of:
 
 In common files `calculus.py` and `test_calculus.py` create functions and unit tests to calculate the integral using the following algorithm :
 - simpson

--- a/calculus.py
+++ b/calculus.py
@@ -2,7 +2,46 @@
 calculus.py
 """
 
+import scipy.optimize as opt
+
 def dummy():
     """ dummy functions for template file
     just the same function that Dr Thomay made"""
     return 0
+
+def secant_wrapper(func, x0, x1, args=(), tol=1e-6, maxiter=50):
+    """
+    Wrapper for the secant method using scipy.optimize.root_scalar.
+
+    Parameters:
+    func : The function for which the root is to be found.
+    x0 : The first initial guess (Ideally close to, but less than, the root)
+    x1 : The second initial guess (Ideally close to, but greater than, the root)
+    args : Additional arguments to pass to the function. Must be a tuple
+    tol : Optional tolerance deciding when to stop function (default is 1e-6).
+    maxiter : The maximum number of iterations if convergence is not met (default is 50).
+
+    Returns:
+    A dictionary containing:
+        - 'root': The estimated root.
+        - 'converged': Boolean indicating whether the method converged.
+        - 'iterations': Number of iterations performed.
+        - 'function_calls': Number of function evaluations performed.
+    """
+
+    #Use the secant method
+    res = opt.root_scalar(
+        func,
+        args=args,
+        method="secant",
+        x0=x0,
+        x1=x1,
+        xtol=tol,
+        maxiter=maxiter)
+
+    #Return a callable dictionary
+    return {
+        "root": res.root if res.converged else None,
+        "converged": res.converged,
+        "iterations": res.iterations,
+        "function_calls": res.function_calls}

--- a/calculus.py
+++ b/calculus.py
@@ -2,8 +2,6 @@
 This module implements different integration and root finding algorithms
 """
 from scipy import optimize
-
-
 import numpy as np
 
 import scipy as sp
@@ -258,7 +256,7 @@ def trapezoid_scipy(func, l_lim, u_lim, steps=10000):
     integral_value = sp.integrate.trapezoid(y, x)   # calculate the integral using numpy
     return integral_value
 
-def secant_wrapper(func, x0, x1, args=(), tol=1e-6, maxiter=50):
+def secant_wrapper(func, x0, x1, args=(), maxiter=50):
     """
     Wrapper for the secant method using scipy.optimize.root_scalar.
 
@@ -279,13 +277,13 @@ def secant_wrapper(func, x0, x1, args=(), tol=1e-6, maxiter=50):
     """
 
     #Use the secant method
-    res = opt.root_scalar(
+    res = optimize.root_scalar(
         func,
         args=args,
         method="secant",
         x0=x0,
         x1=x1,
-        xtol=tol,
+        xtol=1e-6,
         maxiter=maxiter)
 
     #Return a callable dictionary


### PR DESCRIPTION
# Added secant method wrapper to root finding task in ```calculus.py```

## Linting
  - The code lints at a 6.67/10. The errors that arise are ```too-many-arguments``` and ```too-many-positional-arguments``` in the ```secant_wrapper``` and ```opt.root_scalar``` functions respectively. There may be a way to get around this, so I'm hoping to fix this before merging.

## Contents
  - Addition of ```secant_wrapper``` function to ```calculus.py```
  - The function takes in as arguments the function for which we wish to find zeros (```func```), initial guess at the location of the zeros (```x0``` and ```x1```), the arguments of ```func``` (```args```), tolerance within which we will find the root (```tol```) and the maximum number of iterations before the function gives up (```maxiter```).
  - The function returns a dictionary in the following format
  - ```python{
        "root": res.root if res.converged else None,
        "converged": res.converged,
        "iterations": res.iterations,
        "function_calls": res.function_calls}```

## Reviewer
- @avgagliardo seems like the guy